### PR TITLE
Add remote task scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - JWT authentication with role-based access
 - Register/login with JWT stored on frontend
 - Task scheduler API with cron syntax
+- Remote task scheduling with one-time or recurring execution
 - System and task logs with filtering
 - Real-time system stats via WebSocket
 

--- a/backend/configs/ws.handler.js
+++ b/backend/configs/ws.handler.js
@@ -13,6 +13,14 @@ function broadcastToWebClients(message) {
     }
 }
 
+function sendToClient(ipAddress, computerName, message) {
+    socketList.forEach(s => {
+        if (s.ipAddress === ipAddress && s.computerName === computerName && s.readyState === WebSocket.OPEN) {
+            try { s.send(message); } catch (e) {}
+        }
+    });
+}
+
 function initWebSocketServer(server) {
     wss = new WebSocket.Server({ server });
 
@@ -99,7 +107,7 @@ module.exports = {
     initWebSocketServer,
     socketList,
     wss,
-    broadcastToWebClients
-=======
-    broadcast
+    broadcastToWebClients,
+    broadcast,
+    sendToClient
 };

--- a/backend/controllers/remoteTask.controller.js
+++ b/backend/controllers/remoteTask.controller.js
@@ -1,0 +1,12 @@
+const remoteManager = require('../services/remoteTaskManager');
+
+exports.create = (req, res) => {
+  const { client, action, payload, scheduleType, cronTime } = req.body;
+  if (!client || !action) return res.status(400).json({ message: 'client and action required' });
+  const task = remoteManager.createTask({ client, action, payload, scheduleType, cronTime });
+  res.status(201).json({ status: 'success', task });
+};
+
+exports.list = (req, res) => {
+  res.json({ status: 'success', tasks: remoteManager.listTasks() });
+};

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -9,6 +9,7 @@ const statsRoute = require('./stats.route');
 const taskRoute = require('./task.route');
 const logRoute = require('./log.route');
 const userRoute = require('./user.route');
+const remoteTaskRoute = require('./remoteTask.route');
 
 
 const router = express.Router();
@@ -23,6 +24,7 @@ router.use('/stats', statsRoute);
 router.use('/tasks', taskRoute);
 router.use('/logs', logRoute);
 router.use('/users', userRoute);
+router.use('/remote-tasks', remoteTaskRoute);
 
 
 router.get('/', (req, res) => {

--- a/backend/routes/remoteTask.route.js
+++ b/backend/routes/remoteTask.route.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const controller = require('../controllers/remoteTask.controller');
+const router = express.Router();
+
+router.post('/', controller.create);
+router.get('/', controller.list);
+
+module.exports = router;

--- a/backend/services/remoteTaskManager.js
+++ b/backend/services/remoteTaskManager.js
@@ -1,0 +1,39 @@
+const cron = require('node-cron');
+const webSocket = require('../configs/ws.handler');
+
+class RemoteTaskManager {
+  constructor() {
+    this.tasks = [];
+    this.nextId = 1;
+  }
+
+  createTask({ client, action, payload, scheduleType = 'one-time', cronTime = '*' }) {
+    const id = this.nextId++;
+    const task = { id, client, action, payload, scheduleType, cronTime, status: 'pending' };
+
+    const send = () => {
+      const message = JSON.stringify({ type: 'remote_task', payload: { action, data: payload } });
+      webSocket.sendToClient(client.ipAddress, client.computerName, message);
+      task.status = 'sent';
+    };
+
+    if (scheduleType === 'recurring') {
+      task.job = cron.schedule(cronTime, send);
+    } else {
+      task.job = cron.schedule(cronTime, () => {
+        send();
+        task.job.stop();
+        task.status = 'completed';
+      });
+    }
+
+    this.tasks.push(task);
+    return task;
+  }
+
+  listTasks() {
+    return this.tasks.map(t => ({ ...t, job: undefined }));
+  }
+}
+
+module.exports = new RemoteTaskManager();

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -1,6 +1,3 @@
-const Tasks = () => <div className="p-4">Tasks Page</div>;
-export default Tasks;
-=======
 import { useEffect, useState } from 'react';
 import request from '../axios';
 


### PR DESCRIPTION
## Summary
- document remote task scheduling in README
- fix websocket handler exports
- add remote task management service and API
- update routes
- clean up tasks page

## Testing
- `npm test` in `backend` *(fails: Invalid package.json)*
- `npm test` in `frontend` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68490a5b4e408332a827e78a323b7c4b