### PR TITLE
Add command console features

### DIFF
--- a/backend/configs/ws.handler.js
+++ b/backend/configs/ws.handler.js
@@ -1,6 +1,7 @@
 const WebSocket = require('ws');
 const systemMonitor = require('../services/systemMonitor');
 const { getStats } = require('../controllers/stats.controller');
+const commandConsole = require('../services/commandConsole');
 
 let socketList = [];
 let wss;
@@ -91,6 +92,13 @@ function handleClientMessage(ws, messageBuffer) {
     if(result[0] == "FROM_WIN_CLIENT") {
         if(result[1] == "CS_SEND_COMPUTERNAME") {
             ws.computerName = result[2];
+        } else if(result[1] == "COMMAND_RESULT") {
+            try {
+                const output = Buffer.from(result[2], 'base64').toString('utf8');
+                commandConsole.addResponse(ws.ipAddress, ws.computerName, output);
+            } catch (e) {
+                console.error('Failed to decode command result', e);
+            }
         }
     }
 }
@@ -99,7 +107,6 @@ module.exports = {
     initWebSocketServer,
     socketList,
     wss,
-    broadcastToWebClients
-=======
+    broadcastToWebClients,
     broadcast
 };

--- a/backend/controllers/command.controller.js
+++ b/backend/controllers/command.controller.js
@@ -1,27 +1,42 @@
 const webSocket = require("./../configs/ws.handler");
 
+const commandConsole = require('../services/commandConsole');
+
 exports.sendScriptToClientAction = async (req, res) => {
     try {
         const { user, type, script } = req.body;
         const SEP = 'sep-x8jmjgfmr9';
+        const encoded = Buffer.from(script, 'utf8').toString('base64');
 
-        const length = webSocket.socketList.length;
-        for (var i = 0; i < length; i++) {
+        let found = false;
+        for (let i = 0; i < webSocket.socketList.length; i++) {
             const socket = webSocket.socketList[i];
-            if (socket.ipAddress == user.ipAddress && socket.computerName == user.computerName) {
-                const message = `FROM_SERVER${SEP}${type}${SEP}${script}`;
-                console.log(message)
+            if (socket.ipAddress === user.ipAddress && socket.computerName === user.computerName) {
+                const message = `FROM_SERVER${SEP}${type}${SEP}${encoded}`;
                 socket.send(message);
+                found = true;
             }
         }
 
-        res.status(200).json({
-            status: 'success'
-        })
+        if (!found) {
+            return res.status(404).json({ status: 'error', message: 'Client not found' });
+        }
+
+        res.status(200).json({ status: 'success' });
     } catch (error) {
         res.status(500).json({
             status: "server_error",
             message: error.message
-        })
+        });
     }
-}
+};
+
+exports.getCommandResponses = (req, res) => {
+    try {
+        const { ipAddress, computerName } = req.query;
+        const data = commandConsole.getResponses(ipAddress, computerName);
+        res.json({ status: 'success', data });
+    } catch (error) {
+        res.status(500).json({ status: 'server_error', message: error.message });
+    }
+};

--- a/backend/routes/command.route.js
+++ b/backend/routes/command.route.js
@@ -4,6 +4,8 @@ const commandController = require('../controllers/command.controller');
 const router = express.Router();
 
 router.post('/send-script-to-client', commandController.sendScriptToClientAction);
+router.post('/send', commandController.sendScriptToClientAction);
+router.get('/responses', commandController.getCommandResponses);
 
 router.get('/', (req, res) => {
     res.status(200).json({

--- a/backend/services/commandConsole.js
+++ b/backend/services/commandConsole.js
@@ -1,0 +1,20 @@
+const responses = {};
+
+function getKey(ip, computerName) {
+  return `${ip || 'unknown'}_${computerName || 'unknown'}`;
+}
+
+function addResponse(ip, computerName, output) {
+  const key = getKey(ip, computerName);
+  if (!responses[key]) responses[key] = [];
+  responses[key].push({ output, timestamp: Date.now() });
+}
+
+function getResponses(ip, computerName) {
+  return responses[getKey(ip, computerName)] || [];
+}
+
+module.exports = {
+  addResponse,
+  getResponses,
+};

--- a/frontend/src/components/CommandOutputViewer.tsx
+++ b/frontend/src/components/CommandOutputViewer.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import request from '../axios';
+import { UserInfo } from '../types/types';
+
+interface Props {
+  user: UserInfo;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+interface ResponseItem {
+  output: string;
+  timestamp: number;
+}
+
+const CommandOutputViewer: React.FC<Props> = ({ user, isOpen, onClose }) => {
+  const [responses, setResponses] = useState<ResponseItem[]>([]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    async function fetchData() {
+      const res = await request({
+        url: '/command/responses',
+        method: 'GET',
+        params: { ipAddress: user.ipAddress, computerName: user.computerName },
+      });
+      setResponses(res.data.data || []);
+    }
+    fetchData();
+  }, [isOpen, user]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-gray-500 bg-opacity-75 flex justify-center items-center z-[9999]">
+      <div className="bg-white p-6 rounded-lg shadow-lg max-w-lg w-full">
+        <h2 className="text-xl font-semibold mb-4">Command Output</h2>
+        <div className="mb-4 overflow-y-auto max-h-60 bg-gray-100 p-2 rounded">
+          {responses.map((r, idx) => (
+            <div key={idx} className="mb-2">
+              <div className="text-xs text-gray-500">{new Date(r.timestamp).toLocaleString()}</div>
+              <pre className="whitespace-pre-wrap">{r.output}</pre>
+            </div>
+          ))}
+        </div>
+        <div className="flex justify-end">
+          <button onClick={onClose} className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">Close</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CommandOutputViewer;

--- a/frontend/src/components/TransferModal.tsx
+++ b/frontend/src/components/TransferModal.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { UserInfo } from '../types/types';
-import request from '../axios';
 import dayjs from 'dayjs';
 
 interface Props {
@@ -18,15 +17,7 @@ const TransferModal: React.FC<Props> = ({ isOpen, user, setIsOpen, handleProcess
 
   const sendCommand = () => {
     if (!selectedOption) return;
-    request({
-      url: '/command/send',
-      method: 'POST',
-      data: {
-        user,
-        type: selectedOption,
-        script: textContent,
-      },
-    }).then(() => setIsOpen(false));
+    handleProcess(user, selectedOption, textContent);
   };
 
   const disconnectClient = () => {

--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -2,12 +2,14 @@ import { useState } from 'react';
 import request from '../axios';
 import { useWebSocket } from '../hooks/useWebSocket';
 import TransferModal from '../components/TransferModal';
+import CommandOutputViewer from '../components/CommandOutputViewer';
 import UserTable from '../components/UserTable';
 import { UserInfo } from '../types/types';
 
 export default function Clients() {
   const [tableData, setTableData] = useState<UserInfo[]>([]);
   const [modalStatus, setModalStatus] = useState(false);
+  const [outputOpen, setOutputOpen] = useState(false);
   const [user, setUser] = useState<UserInfo>({
     computerName: 'N/A',
     ipAddress: 'N/A',
@@ -53,10 +55,13 @@ export default function Clients() {
         isOpen={modalStatus}
         user={user}
         setIsOpen={setModalStatus}
-        handleProcess={(user, type, script) =>
-          console.log('[SEND]', user, type, script)
-        }
+        handleProcess={async (u, type, script) => {
+          await request({ url: '/command/send', method: 'POST', data: { user: u, type, script } });
+          setModalStatus(false);
+          setOutputOpen(true);
+        }}
       />
+      <CommandOutputViewer user={user} isOpen={outputOpen} onClose={() => setOutputOpen(false)} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- store per-client command responses
- support base64 encoded scripts and response retrieval
- export command console info over websocket
- add output viewer component and integrate into client page
- simplify TransferModal API usage

## Testing
- `npm test` in `backend` *(fails: Invalid package.json)*
- `npm test` in `frontend` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68490a645fec8332bd2e1074ac90b7b9